### PR TITLE
math: add variance, standardDeviation, correlation, and gcd with tests

### DIFF
--- a/native_modules/math.c
+++ b/native_modules/math.c
@@ -148,6 +148,129 @@ static RuntimeVal *math_median(Environment *env, RuntimeVal **args,
   return (RuntimeVal *)MK_NUMBER(median);
 }
 
+
+static RuntimeVal *math_variance(Environment *env, RuntimeVal **args,
+                                 size_t arg_count) {
+  if (arg_count != 1 || args[0]->type != LIST_T) {
+    error("variance() expects one list argument");
+  }
+
+  ListVal *list = (ListVal *)args[0];
+
+  if (list == NULL || list->size == 0) {
+    return (RuntimeVal *)MK_NUMBER(0);
+  }
+
+  double sum = 0.0;
+  size_t count = 0;
+
+  for (size_t i = 0; i < list->size; i++) {
+    RuntimeVal *item = list->items[i];
+    if (item->type == NUMBER_T) {
+      sum += ((NumberVal *)item)->value;
+      count++;
+    }
+  }
+
+  if (count == 0) {
+    return (RuntimeVal *)MK_NUMBER(0);
+  }
+
+  double mean = sum / count;
+  double squared_diff_sum = 0.0;
+
+  for (size_t i = 0; i < list->size; i++) {
+    RuntimeVal *item = list->items[i];
+    if (item->type == NUMBER_T) {
+      double value = ((NumberVal *)item)->value;
+      double diff = value - mean;
+      squared_diff_sum += diff * diff;
+    }
+  }
+
+  return (RuntimeVal *)MK_NUMBER(squared_diff_sum / count);
+}
+
+static RuntimeVal *math_standard_deviation(Environment *env, RuntimeVal **args,
+                                          size_t arg_count) {
+  RuntimeVal *variance_result = math_variance(env, args, arg_count);
+  if (variance_result->type != NUMBER_T) {
+    return (RuntimeVal *)MK_NUMBER(0);
+  }
+
+  double variance = ((NumberVal *)variance_result)->value;
+  return (RuntimeVal *)MK_NUMBER(sqrt(variance));
+}
+
+static RuntimeVal *math_correlation(Environment *env, RuntimeVal **args,
+                                    size_t arg_count) {
+  if (arg_count != 2 || args[0]->type != LIST_T || args[1]->type != LIST_T) {
+    error("correlation() expects two list arguments");
+  }
+
+  ListVal *x = (ListVal *)args[0];
+  ListVal *y = (ListVal *)args[1];
+  size_t n = (x->size < y->size) ? x->size : y->size;
+
+  if (n == 0) {
+    return (RuntimeVal *)MK_NUMBER(0);
+  }
+
+  double sum_x = 0.0, sum_y = 0.0;
+  size_t count = 0;
+
+  for (size_t i = 0; i < n; i++) {
+    if (x->items[i]->type == NUMBER_T && y->items[i]->type == NUMBER_T) {
+      sum_x += ((NumberVal *)x->items[i])->value;
+      sum_y += ((NumberVal *)y->items[i])->value;
+      count++;
+    }
+  }
+
+  if (count == 0) {
+    return (RuntimeVal *)MK_NUMBER(0);
+  }
+
+  double mean_x = sum_x / count;
+  double mean_y = sum_y / count;
+  double num = 0.0, den_x = 0.0, den_y = 0.0;
+
+  for (size_t i = 0; i < n; i++) {
+    if (x->items[i]->type == NUMBER_T && y->items[i]->type == NUMBER_T) {
+      double dx = ((NumberVal *)x->items[i])->value - mean_x;
+      double dy = ((NumberVal *)y->items[i])->value - mean_y;
+      num += dx * dy;
+      den_x += dx * dx;
+      den_y += dy * dy;
+    }
+  }
+
+  if (den_x == 0.0 || den_y == 0.0) {
+    return (RuntimeVal *)MK_NUMBER(0);
+  }
+
+  return (RuntimeVal *)MK_NUMBER(num / sqrt(den_x * den_y));
+}
+
+static RuntimeVal *math_gcd(Environment *env, RuntimeVal **args,
+                            size_t arg_count) {
+  if (arg_count != 2 || args[0]->type != NUMBER_T || args[1]->type != NUMBER_T) {
+    error("gcd() expects two number arguments");
+    return (RuntimeVal *)MK_NIL();
+  }
+
+  long long a = (long long)llabs((long long)((NumberVal *)args[0])->value);
+  long long b = (long long)llabs((long long)((NumberVal *)args[1])->value);
+
+  while (b != 0) {
+    long long t = b;
+    b = a % b;
+    a = t;
+  }
+
+  return (RuntimeVal *)MK_NUMBER((double)a);
+}
+
 static RuntimeVal *math_average(Environment *env, RuntimeVal **args,
                                 size_t arg_count) {
   if (arg_count != 1 || args[0]->type != LIST_T) {
@@ -195,6 +318,14 @@ void init_math_module(Environment *env) {
               (RuntimeVal *)MK_NATIVE_FN(single_param, 1, math_average));
   declare_owned(env, "median",
               (RuntimeVal *)MK_NATIVE_FN(single_param, 1, math_median));
+  declare_owned(env, "variance",
+              (RuntimeVal *)MK_NATIVE_FN(single_param, 1, math_variance));
+  declare_owned(env, "standardDeviation",
+              (RuntimeVal *)MK_NATIVE_FN(single_param, 1, math_standard_deviation));
+  declare_owned(env, "correlation",
+              (RuntimeVal *)MK_NATIVE_FN(double_param, 2, math_correlation));
+  declare_owned(env, "gcd",
+              (RuntimeVal *)MK_NATIVE_FN(double_param, 2, math_gcd));
   declare_owned(env, "lmin",
               (RuntimeVal *)MK_NATIVE_FN(single_param, 1, math_list_min));
   declare_owned(env, "lmax",

--- a/tests/unit/math_module.zo
+++ b/tests/unit/math_module.zo
@@ -2,7 +2,7 @@
            assert_eq, assert_true,
            test_summary };
 ~> math { abs, sqrt, floor, ceil, round, sin, cos, tan, log, pow, min, max,
-           lmin, lmax, average, median };
+           lmin, lmax, average, median, variance, standardDeviation, correlation, gcd };
 
 suite("Math module");
 
@@ -49,7 +49,19 @@ $ math_list_minmax() {
 $ math_stats() {
     let ns = {1, 2, 3, 4, 5};
     assert_eq(average(ns), 3);
-    assert_eq(median(ns),  3)
+    assert_eq(median(ns),  3);
+    assert_eq(variance({1, 2, 3, 4}), 1.25);
+    assert_eq(standardDeviation({1, 2, 3, 4}), sqrt(1.25))
+}
+
+
+$ math_correlation() {
+    assert_eq(correlation({1, 2, 3}, {4, 5, 6}), 1)
+}
+
+$ math_gcd() {
+    assert_eq(gcd(12, 18), 6);
+    assert_eq(gcd(18, 12), 6)
 }
 
 $ math_trig() {
@@ -63,7 +75,9 @@ test("rounding",     math_rounding);
 test("pow",          math_pow);
 test("min / max",    math_minmax);
 test("lmin / lmax",  math_list_minmax);
-test("average / median", math_stats);
+test("average / median / variance / stddev", math_stats);
+test("correlation", math_correlation);
+test("gcd", math_gcd);
 test("trig at 0",    math_trig);
 
 test_summary()


### PR DESCRIPTION
### Motivation

- Extend the math native module with common statistical utilities and number utilities used by higher-level code. 
- Provide `variance` and `standardDeviation` to compute dataset dispersion, `correlation` for pairwise linear correlation, and `gcd` for integer greatest common divisor.

### Description

- Added `math_variance` which computes population variance over numeric items in a `list` and returns `0` for empty or non-numeric-only lists. 
- Added `math_standard_deviation` which calls `math_variance` and returns the square root of the variance. 
- Added `math_correlation` which computes Pearson correlation coefficient for two numeric `list`s and returns `0` on empty input or zero variance. 
- Added `math_gcd` implementing the Euclidean algorithm using `llabs` for input normalization and registered the new native functions in `init_math_module` in `native_modules/math.c`. 
- Extended `tests/unit/math_module.zo` to include tests for `variance`, `standardDeviation`, `correlation`, and `gcd`, and updated test names/registrations accordingly.

### Testing

- Ran the unit test file `tests/unit/math_module.zo` which was updated to exercise the new functions. 
- All added and existing unit tests executed and passed. 
- No changes were made to existing math functions behavior as verified by the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f757d9a1d88320a4d4614b43b7db68)